### PR TITLE
Fixing import of v-interpolate. Removing .js extension.

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { vInterpolate } from '~/directives/v-interpolate.js'
+import { vInterpolate } from '@/directives/v-interpolate'
 
 // TODO: Please sanitize your content before using v-html!
 const contentFromApiCall = `


### PR DESCRIPTION
The import had a .js extension, but the file had a .ts extension.